### PR TITLE
fix: add default item to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "default": "./dist/index.cjs",
       "types": "./dist/index.d.ts",
       "require": "./dist/index.cjs"
     },


### PR DESCRIPTION
When trying to run prettier from terminal this error happens:

```sh
$ prettier -uw '**/*.*'
[error] No "exports" main defined in
~/sample_project/node_modules/prettier-plugin-taplo/package.json
imported from ~/sample_project/noop.js
error: script "format" exited with code 1 (SIGHUP)
```

I researched about the error and apparently it is needed to define a main (default item) for it.

I tested the change and now prettier runs without issues with this plugin.

Solves #32 